### PR TITLE
fix: Re-enable the test

### DIFF
--- a/.github/workflows/endtoend-tests.yaml
+++ b/.github/workflows/endtoend-tests.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   suite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/golangci.yaml
+++ b/.github/workflows/golangci.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/image-build-pr.yaml
+++ b/.github/workflows/image-build-pr.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
@@ -16,5 +16,5 @@ jobs:
           make image
       - name: Push
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          echo ${{ secrets.DOCKER_TOKEN }} | docker login -u hyperledgerk8s --password-stdin
           make image-push image-push-latest

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   suite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   sync:
     if: github.repository == 'bestchains/fabric-operator'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: tgymnich/fork-sync@v1.6.3
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   make-checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up go

--- a/pkg/initializer/ca/tls/tls_test.go
+++ b/pkg/initializer/ca/tls/tls_test.go
@@ -82,7 +82,7 @@ var _ = Describe("generating TLS crypto", func() {
 			Expect(cert.Subject.OrganizationalUnit).To(Equal([]string{"Blockchain"}))
 
 			Expect(cert.DNSNames[0]).To(Equal("localhost"))
-			Expect(string(cert.IPAddresses[0])).To(Equal("127.0.0.1"))
+			Expect(cert.IPAddresses[0].String()).To(Equal("127.0.0.1"))
 
 			Expect(cert.Subject).To(Equal(cert.Issuer))
 		})

--- a/pkg/offering/common/reconcilechecks/fabricversion.go
+++ b/pkg/offering/common/reconcilechecks/fabricversion.go
@@ -66,17 +66,17 @@ func FabricVersionHelper(instance Instance, versions *deployer.Versions, update 
 	return FabricVersion(instance, update, image, fv)
 }
 
-// Image defines the contract with the image checks
-//
 //go:generate counterfeiter -o mocks/image.go -fake-name Image . Image
+
+// Image defines the contract with the image checks
 type Image interface {
 	UpdateRequired(images.Update) bool
 	SetDefaults(images.Instance) error
 }
 
-// Version defines the contract with the version checks
-//
 //go:generate counterfeiter -o mocks/version.go -fake-name Version . Version
+
+// Version defines the contract with the version checks
 type Version interface {
 	Normalize(images.FabricVersionInstance) string
 	Validate(images.FabricVersionInstance) error

--- a/pkg/restart/staggerrestarts/staggerrestarts.go
+++ b/pkg/restart/staggerrestarts/staggerrestarts.go
@@ -63,9 +63,8 @@ func New(client k8sclient.Client, timeout time.Duration) *StaggerRestartsService
 
 // Restart is called by the restart manager.
 // For CA/Peer/Orderer: adds component to the queue for restart.
-// For Console: 		restarts the component directly as there is only one ibpconsole
-//
-//	instance per network. We bypass the queue logic for ibpconsoles.
+// For Console: restarts the component directly as there is only one ibpconsole
+// instance per network. We bypass the queue logic for ibpconsoles.
 func (s *StaggerRestartsService) Restart(instance Instance, reason string) error {
 	switch instance.(type) {
 	case *current.IBPConsole:


### PR DESCRIPTION
1. workflow need 22.04, bacause `peer: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.34' not found (required by peer)`
2. `pkg/offering/common/reconcilechecks/fabricversion.go` and `pkg/restart/staggerrestarts/staggerrestarts.go` are changed to adapt to go 1.19 gofmt parsing of comments
3. `pkg/initializer/ca/tls/tls_test.go` fixes the bug I introduced in pr before to fix golangci issues.
4. `.github/workflows/image-build.yaml` change docker push registry to docker.io/hyperledgerk8s