### PR TITLE
Sync hyperledger-labs/fabric-operator

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -3,18 +3,49 @@ name: Build Operator image
 on:
   push:
     branches: [main]
+env:
+  GO_VER: 1.18.4
+  GO_TAGS: ""
 
 jobs:
   image:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
-      - name: Build
+      - name: Test Build
         run: |
           scripts/install-tools.sh
           make image
-      - name: Push
-        run: |
-          echo ${{ secrets.DOCKER_TOKEN }} | docker login -u hyperledgerk8s --password-stdin
-          make image-push image-push-latest
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+          config-inline: |
+            [worker.oci]
+              max-parallelism = 1
+      - name: Login to the dockerhub Registry
+        uses: docker/login-action@v2
+        with:
+          username: hyperledgerk8s
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - uses: benjlevesque/short-sha@v2.1
+        name: Get short commit sha
+        id: short-sha
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            hyperledgerk8s/fabric-operator:latest
+            hyperledgerk8s/fabric-operator:${{ steps.short-sha.outputs.sha }}
+          push: true
+          build-args: |
+            GO_VER=${{ env.GO_VER }}
+            GO_TAGS=${{ env.GO_TAGS }}
+            BUILD_ID=${{ env.SEMREV_LABEL }}
+            BUILD_DATE=${{ env.BUILD_DATE }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,91 @@
+name: Release Operator
+
+on:
+  pull_request:
+    branches: [ release-1.0 ]
+  push:
+    tags: [ v1.* ]
+
+env:
+  GO_VER: 1.18.4
+  GO_TAGS: ""
+  REGISTRY: docker.io
+  IMAGE_NAME: hyperledgerk8s/fabric-operator
+  SEMREV_LABEL: ${{ github.ref_name }}
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-20.04
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+          config-inline: |
+            [worker.oci]
+              max-parallelism = 1
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Login to the dockerhub Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: hyperledgerk8s
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GO_VER=${{ env.GO_VER }}
+            GO_TAGS=${{ env.GO_TAGS }}
+            BUILD_ID=${{ env.SEMREV_LABEL }}
+            BUILD_DATE=${{ env.BUILD_DATE }}
+
+
+  create-release:
+    name: Create GitHub Release
+    needs: [ build-and-push-image ]
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Release Operator Version
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: "true"
+          bodyFile: release_notes/${{ env.SEMREV_LABEL }}.md
+          tag: ${{ env.SEMREV_LABEL }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -19,9 +19,8 @@
 name: unit-tests
 
 on:
-  # TODO: uncomment this when moved to hyperledger-labs repo
-  # push:
-  #   branches: [main]
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -39,8 +38,7 @@ jobs:
           go-version: ${{ env.GO_VER }}
       - name: license header checks
         run: scripts/check-license.sh
-      # TODO: run in hyperledger-labs
-      # - name: gosec
-      #   run: scripts/go-sec.sh
+      - name: gosec
+        run: scripts/go-sec.sh
       - name: run tests
         run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-ARG ARCH
-ARG REGISTRY
 ARG GO_VER
 
 ########## Build operator binary ##########
 FROM registry.access.redhat.com/ubi8/go-toolset:$GO_VER as builder
-COPY . /go/src/github.com/IBM-Blockchain/fabric-operator
-WORKDIR /go/src/github.com/IBM-Blockchain/fabric-operator
-RUN GOOS=linux GOARCH=$(go env GOARCH) CGO_ENABLED=1 go build -mod=vendor -tags "pkcs11" -gcflags all=-trimpath=${GOPATH} -asmflags all=-trimpath=${GOPATH} -o /tmp/build/_output/bin/ibp-operator
+
+COPY . /go/src/github.com/hyperledger-labs/fabric-operator
+WORKDIR /go/src/github.com/hyperledger-labs/fabric-operator
+
+# RUN GOOS=linux GOARCH=$(go env GOARCH) CGO_ENABLED=1 go build
+RUN go build \
+    -tags "pkcs11" \
+    -gcflags all=-trimpath=${GOPATH} \
+    -asmflags all=-trimpath=${GOPATH} \
+    -o /tmp/build/_output/bin/ibp-operator
 
 ########## Final Image ##########
 FROM registry.access.redhat.com/ubi8/ubi-minimal
@@ -19,6 +24,7 @@ COPY definitions /definitions
 COPY config/crd/bases /deploy/crds
 COPY defaultconfig /defaultconfig
 COPY docker-entrypoint.sh .
+
 RUN microdnf update \
     && microdnf install -y \
     shadow-utils \

--- a/Makefile
+++ b/Makefile
@@ -19,44 +19,43 @@
 IMAGE ?= hyperledgerk8s/fabric-operator
 TAG ?= $(shell git rev-parse --short HEAD)
 ARCH ?= $(shell go env GOARCH)
-OSS_GO_VER ?= 1.17.7
-BUILD_DATE = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 OS = $(shell go env GOOS)
+SEMREV_LABEL ?= v1.0.0-$(shell git rev-parse --short HEAD)
+BUILD_DATE = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+GO_VER ?= 1.18.4
+
+# For compatibility with legacy install-fabric.sh conventions, strip the
+# leading semrev 'v' character when preparing dist and release artifacts.
+VERSION=$(shell echo $(SEMREV_LABEL) | sed -e  's/^v\(.*\)/\1/')
 
 DOCKER_IMAGE_REPO ?= ""
 
-BUILD_ARGS=--build-arg ARCH=$(ARCH)
-BUILD_ARGS+=--build-arg BUILD_ID=$(TAG)
+DOCKER_BUILD ?= docker build
+
+BUILD_ARGS+=--build-arg BUILD_ID=$(VERSION)
 BUILD_ARGS+=--build-arg BUILD_DATE=$(BUILD_DATE)
-BUILD_ARGS+=--build-arg GO_VER=$(OSS_GO_VER)
-
-ifneq ($(origin TRAVIS_PULL_REQUEST),undefined)
-	ifneq ($(TRAVIS_PULL_REQUEST), false)
-		TAG=pr-$(TRAVIS_PULL_REQUEST)
-	endif
-endif
-
-NAMESPACE ?= n$(shell echo $(TAG) | tr -d "-")
+BUILD_ARGS+=--build-arg GO_VER=$(GO_VER)
 
 .PHONY: build
 
-build: ## Builds the starter pack
+build:
 	mkdir -p bin && go build -o bin/operator
 
 image: setup
-	docker build --rm . -f Dockerfile $(BUILD_ARGS) -t $(IMAGE):$(TAG)-$(ARCH)
-	docker tag $(IMAGE):$(TAG)-$(ARCH) $(IMAGE):latest-$(ARCH)
+	$(DOCKER_BUILD) -f Dockerfile $(BUILD_ARGS) -t $(IMAGE):$(TAG) .
+	docker tag $(IMAGE):$(TAG) $(IMAGE):latest
+
+image-multi-arch: setup
+	@printf "[worker.oci]\n\
+	  max-parallelism = 1" > /tmp/buildkitd.toml
+	docker buildx create --use --config /tmp/buildkitd.toml
+	docker buildx build -f Dockerfile $(BUILD_ARGS) -t $(IMAGE):$(TAG) --platform=linux/arm64,linux/amd64 . --push
+	docker buildx build -f Dockerfile $(BUILD_ARGS) -t $(IMAGE):latest --platform=linux/arm64,linux/amd64 . --push
 
 govendor:
 	@go mod vendor
 
 setup: govendor manifests bundle generate
-
-image-push:
-	docker push $(IMAGE):$(TAG)-$(ARCH)
-
-image-push-latest:
-	docker push $(IMAGE):latest-$(ARCH)
 
 login:
 	docker login --username $(DOCKER_USERNAME) --password $(DOCKER_PASSWORD) $(DOCKER_IMAGE_REPO)
@@ -159,14 +158,6 @@ vet:
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
-# Build the docker image
-docker-build: test
-	docker build . -t ${IMG}
-
-# Push the docker image
-docker-push:
-	docker push ${IMG}
-
 # find or download controller-gen
 # download controller-gen if necessary
 controller-gen:
@@ -207,7 +198,7 @@ ifeq (, $(shell which kustomize))
 	KUSTOMIZE_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$KUSTOMIZE_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go install sigs.k8s.io/kustomize/kustomize/v3@v3.5.4 ;\
+	go install sigs.k8s.io/kustomize/kustomize/v4@v4.5.7 ;\
 	rm -rf $$KUSTOMIZE_GEN_TMP_DIR ;\
 	}
 KUSTOMIZE=$(GOBIN)/kustomize

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,15 +6,10 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=fabric-opensource-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.19.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.24.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
-
-# Labels for testing.
-LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
-LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 # Copy files to locations specified by labels.
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
-COPY bundle/tests/scorecard /tests/scorecard/

--- a/bundle/manifests/fabric-opensource-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/fabric-opensource-operator.clusterserviceversion.yaml
@@ -9,11 +9,11 @@ metadata:
     containerImage: todo:update
     createdAt: "2020-07-14T00:00:00Z"
     description: TODO
-    operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.24.1
     operators.operatorframework.io/internal-objects: '["ibpcas.ibp.com","ibppeers.ibp.com","ibporderers.ibp.com"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: ""
-  name: fabric-opensource-operator.v1.0.0
+  name: fabric-opensource-operator.v1.0.0-9726bb6
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1886,4 +1886,4 @@ spec:
   maturity: alpha
   provider:
     name: Opensource
-  version: 1.0.0
+  version: 1.0.0-9726bb6

--- a/bundle/manifests/ibp.com_ibpcas.yaml
+++ b/bundle/manifests/ibp.com_ibpcas.yaml
@@ -1,20 +1,3 @@
-#
-# Copyright contributors to the Hyperledger Fabric Operator project
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at:
-#
-# 	  http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bundle/manifests/ibp.com_ibpconsoles.yaml
+++ b/bundle/manifests/ibp.com_ibpconsoles.yaml
@@ -1,20 +1,3 @@
-#
-# Copyright contributors to the Hyperledger Fabric Operator project
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at:
-#
-# 	  http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bundle/manifests/ibp.com_ibporderers.yaml
+++ b/bundle/manifests/ibp.com_ibporderers.yaml
@@ -1,20 +1,3 @@
-#
-# Copyright contributors to the Hyperledger Fabric Operator project
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at:
-#
-# 	  http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bundle/manifests/ibp.com_ibppeers.yaml
+++ b/bundle/manifests/ibp.com_ibppeers.yaml
@@ -1,20 +1,3 @@
-#
-# Copyright contributors to the Hyperledger Fabric Operator project
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at:
-#
-# 	  http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,10 +5,6 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: fabric-opensource-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.19.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.24.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-
-  # Annotations for testing.
-  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
-  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,6 +42,7 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+        name: controller-manager
     spec:
       containers:
         - command:

--- a/integration/orderer/orderer_suite_test.go
+++ b/integration/orderer/orderer_suite_test.go
@@ -88,10 +88,6 @@ var _ = AfterSuite(func() {
 		return
 	}
 
-	if strings.ToLower(os.Getenv("SAVE_TEST")) == "true" {
-		return
-	}
-
 	err := integration.Cleanup(GinkgoWriter, kclient, namespace)
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/pkg/offering/k8s/orderer/node.go
+++ b/pkg/offering/k8s/orderer/node.go
@@ -201,11 +201,8 @@ func (n *Node) Reconcile(instance *current.IBPOrderer, update baseorderer.Update
 	}
 
 	if update.MSPUpdated() {
-		err = n.UpdateMSPCertificates(instance)
-		if err != nil {
-			if err != nil {
-				return common.Result{}, errors.Wrap(err, "failed to update certificates passed in MSP spec")
-			}
+		if err = n.UpdateMSPCertificates(instance); err != nil {
+			return common.Result{}, errors.Wrap(err, "failed to update certificates passed in MSP spec")
 		}
 	}
 

--- a/pkg/offering/openshift/orderer/node.go
+++ b/pkg/offering/openshift/orderer/node.go
@@ -201,11 +201,8 @@ func (n *Node) Reconcile(instance *current.IBPOrderer, update baseorderer.Update
 	}
 
 	if update.MSPUpdated() {
-		err = n.UpdateMSPCertificates(instance)
-		if err != nil {
-			if err != nil {
-				return common.Result{}, errors.Wrap(err, "failed to update certificates passed in MSP spec")
-			}
+		if err = n.UpdateMSPCertificates(instance); err != nil {
+			return common.Result{}, errors.Wrap(err, "failed to update certificates passed in MSP spec")
 		}
 	}
 

--- a/release_notes/v1.0.0.md
+++ b/release_notes/v1.0.0.md
@@ -1,0 +1,21 @@
+v1.0.0-beta 
+------------------------
+
+Release Notes
+-------------
+
+Known Vulnerabilities
+---------------------
+none
+
+Resolved Vulnerabilities
+------------------------
+none
+
+Known Issues & Workarounds
+--------------------------
+none
+
+Change Log
+----------
+none

--- a/release_notes/v1.0.4.md
+++ b/release_notes/v1.0.4.md
@@ -1,0 +1,21 @@
+v1.0.4
+------------------------
+
+Release Notes
+-------------
+
+Known Vulnerabilities
+---------------------
+none
+
+Resolved Vulnerabilities
+------------------------
+none
+
+Known Issues & Workarounds
+--------------------------
+none
+
+Change Log
+----------
+none

--- a/sample-network/scripts/run-e2e-test.sh
+++ b/sample-network/scripts/run-e2e-test.sh
@@ -42,7 +42,7 @@ printenv | sort
 # Set up a cluster
 network kind
 
-# Set up ngress and CRDs
+# Set up ingress and CRDs
 network cluster init
 
 # Set up a Fabric Network

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -28,14 +28,13 @@
 ## getOperatorSDK
 sudo rm /usr/local/bin/operator-sdk || true
 
-sdkVersion="1.16.0"
-sdkName="operator-sdk"
+OPERATOR_SDK_VERSION="v1.24.1"
+ARCH=$(go env GOARCH)
+OS=$(go env GOOS)
+URL="https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk_${OS}_${ARCH}"
 
-url="https://github.com/operator-framework/operator-sdk/releases/download/${sdkVersion}/operator-sdk_linux_amd64"
-echo "Installing operator-sdk version $sdkVersion with name of $sdkName"
-wget --quiet --progress=dot:giga -t 2 -T 60 -O $sdkName $url || true
-sudo mkdir -p /usr/local/bin/
-chmod +x $sdkName
-./$sdkName version
-sudo mv $sdkName /usr/local/bin
+echo "Installing operator-sdk version ${OPERATOR_SDK_VERSION} to /usr/local/bin/operator-sdk"
+curl -sL $URL > operator-sdk
+chmod +x operator-sdk
+sudo mv operator-sdk /usr/local/bin
 operator-sdk version


### PR DESCRIPTION
using `git merge` not `git cherry-pick`

Close #11 

The main differences are as follows:
- Update golang from v1.17.7 to v1.18.4
- Update kustomize from v3.5.4 to v4.5.7
- Update operator-sdk from v1.16.0 to v1.24.1
- The image is built as a mix of arm64 and amd64 by default