### PR TITLE
chore: disable gosec and revert /etc/hosts setting in integration test 

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -71,12 +71,6 @@ jobs:
       - name: Install Fabric CRDs
         run: |
           kubectl kustomize config/crd | kubectl apply -f -
-      - name: Add hosts to /etc/hosts
-        run: |
-          sudo echo "127.0.0.1 inttestca-ibpca1-ca.vcap.me" | sudo tee -a /etc/hosts
-          sudo echo "127.0.0.1 inttestca-ibpca2-ca.vcap.me" | sudo tee -a /etc/hosts
-          sudo echo "127.0.0.1 inttestca-ibpca3-ca.vcap.me" | sudo tee -a /etc/hosts
-          sudo echo "127.0.0.1 inttestca-interca-ca.vcap.me" | sudo tee -a /etc/hosts
       - name: Run ${{ matrix.suite }} integration tests
         run: make integration-tests
 #        run: |

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -38,7 +38,7 @@ jobs:
           go-version: ${{ env.GO_VER }}
       - name: license header checks
         run: scripts/check-license.sh
-      - name: gosec
-        run: scripts/go-sec.sh
+          #- name: gosec
+          #run: scripts/go-sec.sh
       - name: run tests
         run: make test


### PR DESCRIPTION
gosec is a good tool, but it needs to be configured with the checks we need, so disable it for now.
After merge https://github.com/bestchains/fabric-operator/pull/38, /etc/hosts setting in integration test is not needed anymore, so revert it.
Signed-off-by: Abirdcfly <fp544037857@gmail.com>