### PR TITLE
fix: webhook shuold allow gc work

### DIFF
--- a/api/v1beta1/webhook.go
+++ b/api/v1beta1/webhook.go
@@ -282,7 +282,7 @@ type defaulter interface {
 
 func isSuperUser(ctx context.Context, user authenticationv1.UserInfo) bool {
 	operatorUser, _ := operatorUserFromContext(ctx)
-	return operatorUser == user.Username || util.ContainsValue("system:masters", user.Groups)
+	return operatorUser == user.Username || util.ContainsValue("system:masters", user.Groups) || util.ContainsValue("system:serviceaccounts:kube-system", user.Groups)
 }
 
 type operatorUserContextKey struct{}


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

webhook should let garbage go.otherwise will cause such error:
```
{"level":"info","ts":1673683687.8344188,"logger":"vote-resource","msg":"validate delete","name":"vote-org1-create-federation-sample","user":"&UserInfo{Username:system:serviceaccount:kube-system:generic-garbage-collector,UID:201cb729-fab1-4559-bbb7-ef2ee367deed,Groups:[system:serviceaccounts system:serviceaccounts:kube-system system:authenticated],Extra:map[string]ExtraValue{},}"}
```