### PR TITLE
fix: federation status cant sync from proposal

### DIFF
--- a/.github/workflows/example-test.yaml
+++ b/.github/workflows/example-test.yaml
@@ -18,15 +18,28 @@ jobs:
   build-image:
     runs-on: ubuntu-latest
     steps:
+      - name: Check whether the image of the same commit has been built.
+        id: cache
+        uses: actions/cache/restore@v3
+        with:
+          key: operator.image-${{ github.sha }}
+          path: /tmp/operator.image.tar
       - uses: actions/checkout@v3
+        # It would be foolish to add the same judgment over and over again, but github action currently does not have
+        # the syntax to skip all the next steps unless we let the pre step fail, and failure is not what we want.
+        # see https://github.com/actions/runner/issues/662
+        if: steps.cache.outputs.cache-hit != 'true'
       - name: Build
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           scripts/install-tools.sh
           make image
       - name: save image to /tmp
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           docker save hyperledgerk8s/fabric-operator:latest > /tmp/operator.image.tar
       - name: Upload operator image
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v3
         with:
           key: operator.image-${{ github.sha }}

--- a/config/samples/example-test.sh
+++ b/config/samples/example-test.sh
@@ -301,15 +301,6 @@ function waitFed() {
 		CURRENT_TIME=$(date +%s)
 		ELAPSED_TIME=$((CURRENT_TIME - START_TIME))
 		if [ $ELAPSED_TIME -gt $TimeoutSeconds ]; then
-
-			#todo remove patch after
-			if [[ $check == "Activated" ]]; then
-				kubectl patch fed $fedName --subresource=status --type='json' \
-					-p='[{"op": "replace", "path": "/status/type", "value": "FederationActivated"}]'
-				START_TIME=CURRENT_TIME
-				continue
-			fi
-
 			error "Timeout reached"
 			exit 1
 		fi

--- a/controllers/federation/predict.go
+++ b/controllers/federation/predict.go
@@ -236,7 +236,13 @@ func (r *ReconcileFederation) ProposalUpdateFunc(e event.UpdateEvent) bool {
 	// Update if member changes
 	if len(newMember) != 0 {
 		fed.Spec.Members = newMember
-		if err := r.client.Update(context.TODO(), fed); err != nil {
+		if err := r.client.Patch(context.TODO(), fed, nil, k8sclient.PatchOption{
+			Resilient: &k8sclient.ResilientPatch{
+				Retry:    3,
+				Into:     &current.Federation{},
+				Strategy: client.MergeFrom,
+			},
+		}); err != nil {
 			log.Error(err, fmt.Sprintf("cant update federation %s", newProposal.Spec.Federation))
 			return false
 		}


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

Sometimes the status of the Federation cannot be `FederationActivated`, Even the proposal is successful.

By the way, cache hit check has been added to the image build step of example-test. When the same commit runs the test repeatedly, duplicate image build can no longer be running.