### PR TITLE
fix: keep network after it has been dissolved

### DIFF
--- a/api/v1beta1/network_webhook.go
+++ b/api/v1beta1/network_webhook.go
@@ -33,6 +33,7 @@ import (
 var (
 	errNoFederation          = errors.New("cant find federation")
 	errMemberNotInFederation = errors.New("some member not belongs to this federation")
+	errOnlyDissolvedNetwork  = errors.New("only dissolved network can be deleted")
 )
 
 // log is for logging in this package.
@@ -96,6 +97,11 @@ func (r *Network) ValidateDelete(ctx context.Context, client client.Client, user
 	if err := validateInitiator(ctx, client, user, r.Spec.Members); err != nil {
 		return err
 	}
+
+	if r.Status.CRStatus.Type != NetworkDissoleved {
+		return errOnlyDissolvedNetwork
+	}
+
 	return nil
 }
 

--- a/config/samples/example-test.sh
+++ b/config/samples/example-test.sh
@@ -361,6 +361,11 @@ function waitNetwork() {
 			if [[ $name == "" ]]; then
 				break
 			fi
+		elif [[ $want == "Dissolved" ]]; then
+			Type=$(kubectl get network ${networkName} --token=${token} --ignore-not-found=true -o json | jq -r '.status.type')
+			if [[ $Type == "NetworkDissolved" ]]; then
+				break
+			fi			
 		elif [[ $want == "Ready" ]]; then
 			Type=$(kubectl get network ${networkName} --token=${token} --ignore-not-found=true -o json | jq -r '.status.type')
 			if [[ $Type == "Deployed" ]]; then
@@ -404,7 +409,11 @@ kubectl patch vote -n org2 vote-org2-dissolve-network-sample --type='json' -p='[
 info "4.4.3.3 pro=dissolve-network-sample become Activated"
 waitProposalSucceeded dissolve-network-sample ${Admin2Token}
 
-info "4.4.3.4 network=network-sample cant find, deletion finished"
+info "4.4.3.4 network=network-sample status.type become Dissolved, dissolve finished"
+waitNetwork network-sample "" "Dissolved" "" ${Admin2Token}
+
+info "4.4.3.5 delete network-sample after dissolved"
+kubectl delete -f config/samples/ibp.com_v1beta1_network.yaml --token=${Admin1Token}
 waitNetwork network-sample "" "NoExist" "" ${Admin2Token}
 
 info "4.7 channel management"

--- a/pkg/rbac/synchronizer.go
+++ b/pkg/rbac/synchronizer.go
@@ -65,7 +65,7 @@ func SyncFederation(c controllerclient.Client, o v1.Object, ra ResourceAction) e
 	}
 
 	// PolicyRule which should be appended/removed from role's rules
-	targetRule := PolicyRule(Federation, []v1.Object{o}, []Verb{Get})
+	targetRule := PolicyRule(Federation, []v1.Object{o}, []Verb{Get, Delete})
 
 	// Make sure each organization sync on above rule
 	for _, member := range federation.GetMembers() {
@@ -126,7 +126,7 @@ func SyncNetwork(c controllerclient.Client, o v1.Object, ra ResourceAction) erro
 		return ErrBadSynchronizer
 	}
 	// PolicyRule which should be appended/removed from role's rules
-	targetRule := PolicyRule(Network, []v1.Object{o}, []Verb{Get})
+	targetRule := PolicyRule(Network, []v1.Object{o}, []Verb{Get, Delete})
 	// Make sure each organization sync on above rule
 	for _, member := range network.GetMembers() {
 		organization := &current.Organization{}


### PR DESCRIPTION
Fix: #151 

Changelog:
1. patch network status to `NetworkDissolved` instead of deleting immediately
2. authuorize `Delete` permission to network members 
3. refuse network deletetion if its status is not `NetworkDissolved`
4. update `example-test.sh` accordingly