### PR TITLE
fix: reenable integration test

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -70,9 +70,27 @@ jobs:
 
       - name: Set up KIND k8s cluster
         run: |
+          function debug() {
+            kubectl describe node -A
+            kubectl describe po -A
+            kubectl get po -A
+            exit 1
+          }
+          trap debug ERR
+          RootPath=$(dirname -- "$(readlink -f -- "$0")")/../..
           make kind
           kubectl config view --raw > /tmp/kubeconfig.yaml
-
+          InstallDirPath="/tmp/installer"
+          git clone https://github.com/bestchains/installer.git ${InstallDirPath}
+          cd ${InstallDirPath}
+          kubectl create namespace baas-system
+          cd fabric-operator/charts
+          helm --wait --timeout=600s -nbaas-system install --set consoleIngress.enabled=false --set resources.requests.memory=1Mi fabric-minio minio
+          helm --wait --timeout=600s -nbaas-system install fabric-tekton tekton-operator
+          cd ../..
+          sleep 100; # wait tekton-operator ready.
+          find tekton -type f -name "*.yaml" ! -path "*/sample/*" | xargs -n 1 kubectl apply -f
+          cd ${RootPath}
       - name: Install Fabric CRDs
         run: |
           kubectl kustomize config/crd | kubectl apply -f -

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ CRD_OPTIONS ?= "crd:crdVersions=v1"
 
 # KIND cluster for local development, integration, and E2E testing
 KIND_CLUSTER_NAME ?= fabric
-KIND_KUBE_VERSION ?= v1.20.15								# Matches integ IKS cluster rev.  v1.23.4 is current
+KIND_KUBE_VERSION ?= v1.24.4								# Matches integ IKS cluster rev.  v1.23.4 is current
 KIND_NODE_IMAGE   ?= kindest/node:$(KIND_KUBE_VERSION)
 
 # Integration test parameters

--- a/integration/orderer/orderer_test.go
+++ b/integration/orderer/orderer_test.go
@@ -68,9 +68,9 @@ var (
 
 var (
 	defaultRequestsOrderer = corev1.ResourceList{
-		corev1.ResourceCPU:              resource.MustParse("20m"),
-		corev1.ResourceMemory:           resource.MustParse("40M"),
-		corev1.ResourceEphemeralStorage: resource.MustParse("100M"),
+		corev1.ResourceCPU:              resource.MustParse("2m"),
+		corev1.ResourceMemory:           resource.MustParse("4M"),
+		corev1.ResourceEphemeralStorage: resource.MustParse("10M"),
 	}
 
 	defaultLimitsOrderer = corev1.ResourceList{
@@ -80,9 +80,9 @@ var (
 	}
 
 	defaultRequestsProxy = corev1.ResourceList{
-		corev1.ResourceCPU:              resource.MustParse("10m"),
-		corev1.ResourceMemory:           resource.MustParse("20M"),
-		corev1.ResourceEphemeralStorage: resource.MustParse("100M"),
+		corev1.ResourceCPU:              resource.MustParse("1m"),
+		corev1.ResourceMemory:           resource.MustParse("2M"),
+		corev1.ResourceEphemeralStorage: resource.MustParse("10M"),
 	}
 
 	defaultLimitsProxy = corev1.ResourceList{
@@ -260,9 +260,9 @@ var _ = Describe("Interaction between IBP-Operator and Kubernetes cluster", func
 
 				BeforeEach(func() {
 					newResourceRequestsOrderer = map[corev1.ResourceName]resource.Quantity{
-						corev1.ResourceCPU:              resource.MustParse("240m"),
-						corev1.ResourceMemory:           resource.MustParse("480M"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("100M"),
+						corev1.ResourceCPU:              resource.MustParse("24m"),
+						corev1.ResourceMemory:           resource.MustParse("48M"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("10M"),
 					}
 					newResourceLimitsOrderer = map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceCPU:              resource.MustParse("240m"),
@@ -271,9 +271,9 @@ var _ = Describe("Interaction between IBP-Operator and Kubernetes cluster", func
 					}
 
 					newResourceRequestsProxy = map[corev1.ResourceName]resource.Quantity{
-						corev1.ResourceCPU:              resource.MustParse("90m"),
-						corev1.ResourceMemory:           resource.MustParse("180M"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("100M"),
+						corev1.ResourceCPU:              resource.MustParse("9m"),
+						corev1.ResourceMemory:           resource.MustParse("18M"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("10M"),
 					}
 					newResourceLimitsProxy = map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceCPU:              resource.MustParse("90m"),
@@ -916,6 +916,10 @@ func GetOrderer() (*Orderer, []Orderer) {
 				},
 			},
 			Resources: &current.OrdererResources{
+				Init: &corev1.ResourceRequirements{
+					Requests: defaultRequestsOrderer,
+					Limits:   defaultLimitsOrderer,
+				},
 				Orderer: &corev1.ResourceRequirements{
 					Requests: defaultRequestsOrderer,
 					Limits:   defaultLimitsOrderer,
@@ -923,6 +927,10 @@ func GetOrderer() (*Orderer, []Orderer) {
 				GRPCProxy: &corev1.ResourceRequirements{
 					Requests: defaultRequestsProxy,
 					Limits:   defaultLimitsProxy,
+				},
+				Enroller: &corev1.ResourceRequirements{
+					Requests: defaultRequestsOrderer,
+					Limits:   defaultLimitsOrderer,
 				},
 			},
 			ConfigOverride: &runtime.RawExtension{Raw: configBytes},
@@ -1000,6 +1008,10 @@ func GetOrderer2() (*Orderer, []Orderer) {
 			Zone:   "select",
 			Region: "select",
 			Resources: &current.OrdererResources{
+				Init: &corev1.ResourceRequirements{
+					Requests: defaultRequestsOrderer,
+					Limits:   defaultLimitsOrderer,
+				},
 				Orderer: &corev1.ResourceRequirements{
 					Requests: defaultRequestsOrderer,
 					Limits:   defaultLimitsOrderer,
@@ -1007,6 +1019,10 @@ func GetOrderer2() (*Orderer, []Orderer) {
 				GRPCProxy: &corev1.ResourceRequirements{
 					Requests: defaultRequestsProxy,
 					Limits:   defaultLimitsProxy,
+				},
+				Enroller: &corev1.ResourceRequirements{
+					Requests: defaultRequestsOrderer,
+					Limits:   defaultLimitsOrderer,
 				},
 			},
 			DisableNodeOU: pointer.Bool(true),
@@ -1104,6 +1120,24 @@ func GetOrderer3() (*Orderer, []Orderer) {
 					Region: "us-south2",
 				},
 			},
+			Resources: &current.OrdererResources{
+				Init: &corev1.ResourceRequirements{
+					Requests: defaultRequestsOrderer,
+					Limits:   defaultLimitsOrderer,
+				},
+				Orderer: &corev1.ResourceRequirements{
+					Requests: defaultRequestsOrderer,
+					Limits:   defaultLimitsOrderer,
+				},
+				GRPCProxy: &corev1.ResourceRequirements{
+					Requests: defaultRequestsProxy,
+					Limits:   defaultLimitsProxy,
+				},
+				Enroller: &corev1.ResourceRequirements{
+					Requests: defaultRequestsOrderer,
+					Limits:   defaultLimitsOrderer,
+				},
+			},
 			DisableNodeOU: pointer.Bool(true),
 			FabricVersion: integration.FabricVersion + "-1",
 		},
@@ -1178,6 +1212,10 @@ func GetOrderer4() (*Orderer, []Orderer) {
 			Zone:   "select",
 			Region: "select",
 			Resources: &current.OrdererResources{
+				Init: &corev1.ResourceRequirements{
+					Requests: defaultRequestsOrderer,
+					Limits:   defaultLimitsOrderer,
+				},
 				Orderer: &corev1.ResourceRequirements{
 					Requests: defaultRequestsOrderer,
 					Limits:   defaultLimitsOrderer,
@@ -1185,6 +1223,10 @@ func GetOrderer4() (*Orderer, []Orderer) {
 				GRPCProxy: &corev1.ResourceRequirements{
 					Requests: defaultRequestsProxy,
 					Limits:   defaultLimitsProxy,
+				},
+				Enroller: &corev1.ResourceRequirements{
+					Requests: defaultRequestsOrderer,
+					Limits:   defaultLimitsOrderer,
 				},
 			},
 			DisableNodeOU: pointer.Bool(true),
@@ -1275,6 +1317,10 @@ func GetOrderer5() (*Orderer, []Orderer) {
 				},
 			},
 			Resources: &current.OrdererResources{
+				Init: &corev1.ResourceRequirements{
+					Requests: defaultRequestsOrderer,
+					Limits:   defaultLimitsOrderer,
+				},
 				Orderer: &corev1.ResourceRequirements{
 					Requests: defaultRequestsOrderer,
 					Limits:   defaultLimitsOrderer,
@@ -1282,6 +1328,10 @@ func GetOrderer5() (*Orderer, []Orderer) {
 				GRPCProxy: &corev1.ResourceRequirements{
 					Requests: defaultRequestsProxy,
 					Limits:   defaultLimitsProxy,
+				},
+				Enroller: &corev1.ResourceRequirements{
+					Requests: defaultRequestsOrderer,
+					Limits:   defaultLimitsOrderer,
 				},
 			},
 			DisableNodeOU: pointer.Bool(true),


### PR DESCRIPTION
Fix #176

Integration testing is now reactivated:
1. Upgrade the Kubernetes version for integrated testing from 1.20.15 to 1.24.4, consistent with the [bestchains/installer](https://github.com/bestchains/installer/blob/17861acbd9ce70ca3c59bb0a83d33d1a4429396f/scripts/kind.sh#L89).
2. Install Minio and Tekton in advance for integration testing.
3. Reduce the request of all pods in the orderer test.