### PR TITLE
fix: should always set InitRequired to false during chaincode deployment

### DIFF
--- a/api/v1beta1/chaincode_types.go
+++ b/api/v1beta1/chaincode_types.go
@@ -72,8 +72,9 @@ type ChaincodeSpec struct {
 	// current version
 	Version string `json:"version,omitempty"`
 	// +kubebuilder:validation:Pattern:=`^[[:alnum:]][[:alnum:]-]*$`
-	Label        string `json:"label,omitempty"`
-	InitRequired bool   `json:"initRequired"`
+	Label string `json:"label,omitempty"`
+	// +kubebuilder:validation:Enum=false
+	InitRequired bool `json:"initRequired"`
 
 	EndorsePolicyRef `json:"endorsePolicyRef"`
 	// ExternalBuilder used, default is k8s

--- a/config/crd/bases/ibp.com_chaincodes.yaml
+++ b/config/crd/bases/ibp.com_chaincodes.yaml
@@ -64,6 +64,8 @@ spec:
                 - name
                 type: object
               initRequired:
+                enum:
+                - false
                 type: boolean
               label:
                 pattern: ^[[:alnum:]][[:alnum:]-]*$


### PR DESCRIPTION
fix: should always set InitRequired to false during chaincode deployment
Fix: https://github.com/bestchains/fabric-operator/issues/207