### PR TITLE
fix: user annotations update is not always successful

### DIFF
--- a/controllers/network/predict.go
+++ b/controllers/network/predict.go
@@ -131,12 +131,14 @@ func (r *ReconcileNetwork) DeleteFunc(e event.DeleteEvent) bool {
 		return false
 	}
 	targetUser := org.Spec.Admin
-	for i := 0; i < network.Spec.OrderSpec.ClusterSize; i++ {
-		enrollID := fmt.Sprintf("%s%d", network.Name, i)
-		err = user.Reconcile(r.client, targetUser, org.Name, enrollID, user.ORDERER, user.Remove)
-		if err != nil {
-			log.Error(err, "failed to reconcile user when network delete")
-		}
+	size := network.Spec.OrderSpec.ClusterSize
+	enrollIDs := make([]string, size)
+	for i := range enrollIDs {
+		enrollIDs[i] = fmt.Sprintf("%s%d", network.Name, i)
+	}
+	err = user.ReconcileMultiple(r.client, targetUser, org.Name, user.ORDERER, user.Remove, enrollIDs...)
+	if err != nil {
+		log.Error(err, "failed to reconcile user when network delete")
 	}
 	return false
 }

--- a/pkg/offering/base/network/network.go
+++ b/pkg/offering/base/network/network.go
@@ -228,12 +228,14 @@ func (network *BaseNetwork) ReconcileUser(instance *current.Network, update Upda
 		return err
 	}
 	targetUser := org.Spec.Admin
-	for i := 0; i < instance.Spec.OrderSpec.ClusterSize; i++ {
-		enrollID := fmt.Sprintf("%s%d", instance.Name, i)
-		err = user.Reconcile(network.Client, targetUser, org.Name, enrollID, user.ORDERER, user.Add)
-		if err != nil {
-			return err
-		}
+	size := instance.Spec.OrderSpec.ClusterSize
+	enrollIDs := make([]string, size)
+	for i := range enrollIDs {
+		enrollIDs[i] = fmt.Sprintf("%s%d", instance.Name, i)
+	}
+	err = user.ReconcileMultiple(network.Client, targetUser, org.Name, user.ORDERER, user.Add, enrollIDs...)
+	if err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
the default client in sigs.k8s.io/controller-runtime will always write to API, read from cache, so we can't expect to get the latest metadata immediately after patch.

After running 254*2=508 tests in https://github.com/Abirdcfly/fabric-operator/actions/runs/4625063651, it shows that after applying this commit https://github.com/Abirdcfly/fabric-operator/commit/296f152cad1d5dbe9a1dafc4e8948bf5605c228f (Apart from the testing part, the code fix part is consistent with the current pr), the error no longer appears.